### PR TITLE
Add deployment button for Hostinger in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,12 @@ bash misp/configure-threat-feeds.sh
 
 ### ⚡ **Simple Installation**
 
+## Deploy on Hostinger
+
+Quickly deploy using Hostinger with a 1-click installation
+
+[![Deploy on Hostinger](https://assets.hostinger.com/vps/deploy.svg)](https://www.hostinger.com/vps/docker-hosting?compose_url=https://github.com/cyberblu3s/CyberBlue/)
+
 **Complete CyberBlueSOC installation in few commands:**
 
 ```bash


### PR DESCRIPTION
I've added Hostinger 1-click installation badge for fast and easy intall. You can change the URL to contain the referral code to earn commission on every installation. You can also read more here: https://www.hostinger.com/support/deploy-on-hostinger-button/